### PR TITLE
Allow setting core and package keys

### DIFF
--- a/src/DrupalInfo.php
+++ b/src/DrupalInfo.php
@@ -120,7 +120,12 @@ class DrupalInfo implements PluginInterface, EventSubscriberInterface
     protected function doWriteInfoFiles(PackageInterface $package)
     {
         if ($writer = $this->getWriter($package)) {
-            $writer->rewrite($this->findVersion($package), $this->findTimestamp($package));
+            $writer->rewrite(
+                $this->findVersion($package),
+                $this->findTimestamp($package),
+                $this->findCore($package),
+                $this->findPackage($package)
+            );
         } elseif ($this->io->isVerbose()) {
             $this->io->write(
                 '<info>No info files found for ' .$package->getPrettyName() . '</info>'
@@ -193,6 +198,46 @@ class DrupalInfo implements PluginInterface, EventSubscriberInterface
 
         // Last resort, use current time.
         return time();
+    }
+
+    /**
+     * Find the Drupal core version this package is for.
+     *
+     * @param PackageInterface $package
+     *
+     * @return string|null
+     *   Drupal core version, such as "8.x". NULL if unable to determine.
+     */
+    protected function findCore(PackageInterface $package)
+    {
+        // Attempt to determine from getExtra().
+        $extra = $package->getExtra();
+        if (isset($extra['drupal']['core'])) {
+            return $extra['drupal']['core'];
+        }
+
+        // Attempt to determine from version number.
+        $version = $this->findVersion($package);
+        if (preg_match('/^(\d+\.x)-/', $version, $backref)) {
+            return $backref[1];
+        }
+    }
+
+    /**
+     * Find the name of the packge.
+     *
+     * @param PackageInterface $package
+     *
+     * @return string|null
+     *   The package name. NULL if unable to determine.
+     */
+    protected function findPackage(PackageInterface $package)
+    {
+        // Attempt to determine from getExtra().
+        $extra = $package->getExtra();
+        if (isset($extra['drupal']['package'])) {
+            return $extra['drupal']['package'];
+        }
     }
 
     /**

--- a/src/Writer/Drupal.php
+++ b/src/Writer/Drupal.php
@@ -30,13 +30,13 @@ class Drupal implements WriterInterface
     /**
      * {@inheritdoc}
      */
-    public function rewrite($version, $timestamp)
+    public function rewrite($version, $timestamp, $core = null, $project = null)
     {
         foreach ($this->paths as $info_file) {
             // Don't write to files that already contain version information.
             if (!$this->hasVersionInfo($info_file)) {
                 $file = fopen($info_file, 'a+');
-                fwrite($file, $this->formatInfo($version, $timestamp));
+                fwrite($file, $this->formatInfo($version, $timestamp, $core, $project));
                 fclose($file);
             }
         }
@@ -58,7 +58,7 @@ class Drupal implements WriterInterface
     /**
      * Format version and timestamp into YAML.
      */
-    protected function formatInfo($version, $timestamp)
+    protected function formatInfo($version, $timestamp, $core = null, $project = null)
     {
         $date = gmdate('c', $timestamp);
         $info = array();
@@ -66,6 +66,12 @@ class Drupal implements WriterInterface
         $info[] = '';
         $info[] = "# Information added by drupal-composer/info-rewrite on $date.";
         $info[] = "version: '$version'";
+        if ($core) {
+            $info[] = "core: '$core'";
+        }
+        if ($project) {
+            $info[] = "project: '$project'";
+        }
         $info[] = "datestamp: $timestamp";
         // Always end with EOL character.
         $info[] = '';

--- a/src/Writer/Drupal.php
+++ b/src/Writer/Drupal.php
@@ -61,14 +61,16 @@ class Drupal implements WriterInterface
     protected function formatInfo($version, $timestamp)
     {
         $date = gmdate('c', $timestamp);
-        $info = <<<EOL
+        $info = array();
+        // Always start with EOL character.
+        $info[] = '';
+        $info[] = "# Information added by drupal-composer/info-rewrite on $date.";
+        $info[] = "version: '$version'";
+        $info[] = "datestamp: $timestamp";
+        // Always end with EOL character.
+        $info[] = '';
 
-# Information added by drupal-composer/info-rewrite on $date.
-version: '$version'
-datestamp: $timestamp
-
-EOL;
-        return $info;
+        return implode("\n", $info);
     }
 
     /**

--- a/src/Writer/Drupal7.php
+++ b/src/Writer/Drupal7.php
@@ -18,11 +18,15 @@ class Drupal7 extends Drupal
     protected function formatInfo($version, $timestamp)
     {
         $date = gmdate('c', $timestamp);
-        $info = <<<EOL
-; Information added by drupal-composer/info-rewrite on $date.
-version = "$version"
-timestamp = "$timestamp"
+        $info = array();
+        // Always start with EOL character.
+        $info[] = '';
+        $info[] = "; Information added by drupal-composer/info-rewrite on $date.";
+        $info[] = "version = \"$version\"";
+        $info[] = "datestamp = \"$timestamp\"";
+        // Always end with EOL character.
+        $info[] = '';
 
-EOL;
+        return implode("\n", $info);
     }
 }

--- a/src/Writer/Drupal7.php
+++ b/src/Writer/Drupal7.php
@@ -15,7 +15,7 @@ class Drupal7 extends Drupal
     /**
      * Format version and timestamp into INI format.
      */
-    protected function formatInfo($version, $timestamp)
+    protected function formatInfo($version, $timestamp, $core = null, $project = null)
     {
         $date = gmdate('c', $timestamp);
         $info = array();
@@ -23,6 +23,12 @@ class Drupal7 extends Drupal
         $info[] = '';
         $info[] = "; Information added by drupal-composer/info-rewrite on $date.";
         $info[] = "version = \"$version\"";
+        if ($core) {
+            $info[] = "core = \"$core\"";
+        }
+        if ($project) {
+            $info[] = "project = \"$project\"";
+        }
         $info[] = "datestamp = \"$timestamp\"";
         // Always end with EOL character.
         $info[] = '';

--- a/src/Writer/WriterInterface.php
+++ b/src/Writer/WriterInterface.php
@@ -22,7 +22,7 @@ interface WriterInterface
      * @param  string $timestamp
      * @return
      */
-    public function rewrite($version, $timestamp);
+    public function rewrite($version, $timestamp, $core = null, $project = null);
 
     /**
      * Rollback the info files to their download/unprocessed state.


### PR DESCRIPTION
The drupal.org packaging script sets the core and package keys. These commits allow those to be set. It doesn't become fully useful unless PackageInterface::getExtra() determines these values, so this is not complete. It also handles much of what #11 is doing.