### PR TITLE
Allow defining additional package types

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ This is only required when downloading projects that aren't full releases (for i
 ## Installation
 
 `composer require drupal-composer/info-rewrite:~1.0`
+
+## Configuration
+
+By default, this plugin only acts on packages of type `drupal-core`, `drupal-module`, `drupal-profile`, and `drupal-theme` (see DrupalInfo::$packageTypes). You can add additional package types in your `composer.json` file. Add to the `config` array an entry with key `drupal-info-rewrite--additional-packageTypes` and make its value be an array of strings which are the additional types you would like to add.

--- a/src/DrupalInfo.php
+++ b/src/DrupalInfo.php
@@ -52,9 +52,12 @@ class DrupalInfo implements PluginInterface, EventSubscriberInterface
         $this->composer = $composer;
         $this->io = $io;
 
-        $additionalPackageTypes = $this->composer->getConfig()->get('drupal-info-rewrite--additional-packageTypes');
-        if (is_array($additionalPackageTypes)) {
-            $this->packageTypes = array_merge($this->packageTypes, $additionalPackageTypes);
+        $config = $this->composer->getConfig();
+        if ($config) {
+            $additionalPackageTypes = $config->get('drupal-info-rewrite--additional-packageTypes');
+            if (is_array($additionalPackageTypes)) {
+                $this->packageTypes = array_merge($this->packageTypes, $additionalPackageTypes);
+            }
         }
     }
 

--- a/src/DrupalInfo.php
+++ b/src/DrupalInfo.php
@@ -51,6 +51,11 @@ class DrupalInfo implements PluginInterface, EventSubscriberInterface
     {
         $this->composer = $composer;
         $this->io = $io;
+
+        $additionalPackageTypes = $this->composer->getConfig()->get('drupal-info-rewrite--additional-packageTypes');
+        if (is_array($additionalPackageTypes)) {
+            $this->packageTypes = array_merge($this->packageTypes, $additionalPackageTypes);
+        }
     }
 
     /**

--- a/src/DrupalInfo.php
+++ b/src/DrupalInfo.php
@@ -37,7 +37,7 @@ class DrupalInfo implements PluginInterface, EventSubscriberInterface
     /**
      * Package types to process.
      */
-    protected static $packageTypes = [
+    protected $packageTypes = [
         'drupal-core',
         'drupal-module',
         'drupal-profile',
@@ -203,7 +203,7 @@ class DrupalInfo implements PluginInterface, EventSubscriberInterface
      */
     protected function processPackage(PackageInterface $package)
     {
-        return in_array($package->getType(), static::$packageTypes);
+        return in_array($package->getType(), $this->packageTypes);
     }
 
     /**

--- a/tests/DrupalInfoTest.php
+++ b/tests/DrupalInfoTest.php
@@ -91,6 +91,7 @@ class DrupalInfoTest extends \PHPUnit_Framework_TestCase
         $manager->getInstaller('drupal-module')->willReturn($installer->reveal());
         $this->composer = $this->prophesize(Composer::class);
         $this->composer->getInstallationManager()->willReturn($manager->reveal());
+        $this->composer->getConfig()->willReturn(null);
 
         $this->fixture->activate(
             $this->composer->reveal(),
@@ -169,6 +170,7 @@ EOL;
         $manager->getInstaller('drupal-module')->willReturn($installer->reveal());
         $this->composer = $this->prophesize(Composer::class);
         $this->composer->getInstallationManager()->willReturn($manager->reveal());
+        $this->composer->getConfig()->willReturn(null);
         $this->io->write('<info>No info files found for foo</info>')->shouldBeCalled();
         $this->io->isVerbose()->willReturn(true);
         $this->fixture->activate(
@@ -242,6 +244,7 @@ EOL;
         $this->composer = $this->prophesize(Composer::class);
         $this->composer->getRepositoryManager()->willReturn($manager->reveal());
         $this->composer->getInstallationManager()->willReturn($location_manager->reveal());
+        $this->composer->getConfig()->willReturn(null);
 
         $this->fixture->activate(
             $this->composer->reveal(),


### PR DESCRIPTION
In our use case, we need to be able to add additional values to $packageTypes. This pull request allows this to be done with configuration in composer.json.