### PR TITLE
Explain date in "Information added by" line

### DIFF
--- a/src/Writer/Drupal.php
+++ b/src/Writer/Drupal.php
@@ -47,7 +47,7 @@ class Drupal implements WriterInterface
      */
     public function rollback()
     {
-        $pattern = '# Information added by drupal-composer/info-rewrite on';
+        $pattern = '# Information added by drupal-composer/info-rewrite; date of revision:';
         foreach ($this->paths as $info_file) {
             $contents = file_get_contents($info_file);
             $parts = explode($pattern, $contents);
@@ -64,7 +64,7 @@ class Drupal implements WriterInterface
         $info = array();
         // Always start with EOL character.
         $info[] = '';
-        $info[] = "# Information added by drupal-composer/info-rewrite on $date.";
+        $info[] = "# Information added by drupal-composer/info-rewrite; date of revision: $date.";
         $info[] = "version: '$version'";
         if ($core) {
             $info[] = "core: '$core'";

--- a/src/Writer/Drupal7.php
+++ b/src/Writer/Drupal7.php
@@ -21,7 +21,7 @@ class Drupal7 extends Drupal
         $info = array();
         // Always start with EOL character.
         $info[] = '';
-        $info[] = "; Information added by drupal-composer/info-rewrite on $date.";
+        $info[] = "; Information added by drupal-composer/info-rewrite; date of revision: $date.";
         $info[] = "version = \"$version\"";
         if ($core) {
             $info[] = "core = \"$core\"";

--- a/tests/DrupalInfoTest.php
+++ b/tests/DrupalInfoTest.php
@@ -111,7 +111,7 @@ class DrupalInfoTest extends \PHPUnit_Framework_TestCase
             $this->getDirectory() . '/nested_module/modules/module_b/module_b.info.yml',
         ];
         $info = <<<EOL
-# Information added by drupal-composer/info-rewrite on 2009-02-13T23:31:30+00:00.
+# Information added by drupal-composer/info-rewrite; date of revision: 2009-02-13T23:31:30+00:00.
 version: 'foo-x+5'
 datestamp: 123
 EOL;
@@ -214,7 +214,7 @@ EOL;
         ];
         $info_pattern = <<<EOL
 
-# Information added by drupal-composer/info-rewrite on 2001-01-02.
+# Information added by drupal-composer/info-rewrite; date of revision: 2001-01-02.
 version: 'foo-version'
 timestamp: 1234
 EOL;


### PR DESCRIPTION
The "Information added by" line includes the date of the commit, but the sentence is written as if the date is the date that info-rewrite added the information to the file. This pull request uses the current date instead of the date of the commit.