### PR TITLE
Use append-only mode in fopen()

### DIFF
--- a/src/Writer/Drupal.php
+++ b/src/Writer/Drupal.php
@@ -40,7 +40,7 @@ class Drupal implements WriterInterface
         foreach ($this->paths as $info_file) {
             // Don't write to files that already contain version information.
             if (!$this->hasVersionInfo($info_file)) {
-                $file = fopen($info_file, 'a+');
+                $file = fopen($info_file, 'a');
                 $coreToWrite = $this->hasCoreVersionRequirement($info_file) ? null : $core;
                 fwrite($file, $this->formatInfo($version, $timestamp, $coreToWrite, $project));
                 fclose($file);

--- a/tests/DrupalInfoTest.php
+++ b/tests/DrupalInfoTest.php
@@ -221,7 +221,7 @@ version: 'foo-version'
 timestamp: 1234
 EOL;
         foreach ($files as $file) {
-            $handle = fopen($file, 'a+');
+            $handle = fopen($file, 'a');
             fwrite($handle, $info_pattern);
             fclose($handle);
             $this->assertContains($info_pattern, file_get_contents($file));


### PR DESCRIPTION
fopen() is currently given a read-write mode, but it does not read using the resulting file handle. So, it ought to be the append-only mode.